### PR TITLE
adds index tests for paginated result and not

### DIFF
--- a/app/models/concerns/paginatable.rb
+++ b/app/models/concerns/paginatable.rb
@@ -8,8 +8,8 @@ module Paginatable
         per_page = params[:per_page].nil? ? 9 : params[:per_page].to_i
         response[:page] = params[:page].nil? ? 1 : params[:page].to_i
         response[:pages_per_limit] = response[:entries_count] / per_page + 1
-        response[:records] = response[:entries_count] <= per_page ? self.all.order('ASC') :
-                  self.offset((response[:page] - 1) * per_page).order('ASC').limit(per_page)
+        response[:records] = response[:entries_count] <= per_page ? self.all :
+                  self.offset((response[:page] - 1) * per_page).limit(per_page)
         response
       end
       response

--- a/spec/requests/images_controller_spec.rb
+++ b/spec/requests/images_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe V1::ImagesController do
+  before do
+    image1 =  Image.create url: "https://picsum.photos/id/12"
+    image2 = Image.create url: "https://picsum.photos/id/44"
+    image3 = Image.create url: "https://picsum.photos/id/48"
+    host! 'api.example.com'
+  end
+
+   context 'requests the list of all images with no params and gets it in json' do
+    before :each do
+      get v1_images_path
+      @json_body = json_response
+    end
+
+    it 'receives success status' do
+      expect(response).to be_successful
+    end
+
+    it 'receives response as the object with "records", "entries_count", "pages_per_limit", "page" keys' do
+      expect(@json_body.keys).to eq ["records", "entries_count", "pages_per_limit", "page"]
+    end
+
+    it 'receives response with list of images that are in DB by the "records" key in the response object' do
+      image_urls = Image.pluck(:url)
+      returned_urls = @json_body['records'].map {|s| s["url"]}
+      expect(image_urls).to eq returned_urls
+    end
+  end
+
+  context "it requests paginated result" do
+    it 'requests 2nd page with 2 images per page and receives 1 image from 3' do
+      get v1_images_path(per_page: 2, page: 2)
+      expect(json_response['records'].length).to be 1
+      expect(json_response['records'][0]['url']).to eq("https://picsum.photos/id/48")
+    end
+
+    it 'requests 2nd page and forgets to specify the limit and receives 2nd or last page with default of max 9 records per page' do
+      get v1_images_path(page: 2)
+      expect(json_response['records'].length).to be 3
+      expect(json_response['records'].map{|s| s['url']}).to eq ["https://picsum.photos/id/12", "https://picsum.photos/id/44", "https://picsum.photos/id/48"]
+    end
+
+    it 'recieves json with "records", "entries_count", "pages_per_limit" and "page" keys' do
+      get v1_images_path(per_page: 2, page: 2)
+      expect(json_response.keys).to eq(["records", "entries_count", "pages_per_limit", "page"])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,9 @@
 # the additional setup, and require it from the spec files that actually need
 # it.
 #
+def json_response
+  @json_response ||= JSON.parse(response.body)
+end
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -43,6 +46,17 @@ RSpec.configure do |config|
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.


### PR DESCRIPTION
v1/images#index returns json with all records or paginated result based on requested page and amount of records per page.
API works as expected.